### PR TITLE
Add support for setting and retrieving a logger with contexts.

### DIFF
--- a/contexts.go
+++ b/contexts.go
@@ -1,0 +1,18 @@
+package log
+
+import "context"
+
+type loggerKeyType struct{}
+
+var loggerKey = loggerKeyType{}
+
+func WithContext(ctx context.Context, logger Logger) context.Context {
+	return context.WithValue(ctx, loggerKey, logger)
+}
+
+func FromContext(ctx context.Context) Logger {
+	if v, ok := ctx.Value(loggerKey).(Logger); ok {
+		return v
+	}
+	return NewNilLogger()
+}

--- a/contexts.go
+++ b/contexts.go
@@ -6,7 +6,7 @@ type loggerKeyType struct{}
 
 var loggerKey = loggerKeyType{}
 
-func WithContext(ctx context.Context, logger Logger) context.Context {
+func WithLogger(ctx context.Context, logger Logger) context.Context {
 	return context.WithValue(ctx, loggerKey, logger)
 }
 

--- a/contexts_test.go
+++ b/contexts_test.go
@@ -1,0 +1,45 @@
+package log
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/derision-test/glock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithAndFromContext(t *testing.T) {
+	t.Run("from context without value", func(t *testing.T) {
+		ctx := context.Background()
+		assert.Equal(t, NewNilLogger(), FromContext(ctx))
+	})
+	t.Run("from context that has value", func(t *testing.T) {
+		sink := newJSONLogger(nil)
+		buffer := bytes.NewBuffer(nil)
+		timestamp := time.Unix(1628115072, 0)
+		sink.stream = buffer
+
+		clock := glock.NewMockClockAt(timestamp)
+		logger := newTestLogger(sink, LevelDebug, nil, clock, func() {})
+
+		ctx := context.Background()
+		ctx = WithContext(ctx, logger)
+
+		ctxLogger := FromContext(ctx)
+		assert.Same(t, logger, ctxLogger)
+
+		ctxLogger.Info("test 1234")
+
+		// Just make sure the message is correct, we don't care
+		// about anything else since that'll tell us that we got
+		// the correct logger back.
+		logItem := struct {
+			Message string `json:"message"`
+		}{}
+		assert.NoError(t, json.Unmarshal(buffer.Bytes(), &logItem))
+		assert.Equal(t, "test 1234", logItem.Message)
+	})
+}

--- a/contexts_test.go
+++ b/contexts_test.go
@@ -26,7 +26,7 @@ func TestWithAndFromContext(t *testing.T) {
 		logger := newTestLogger(sink, LevelDebug, nil, clock, func() {})
 
 		ctx := context.Background()
-		ctx = WithContext(ctx, logger)
+		ctx = WithLogger(ctx, logger)
 
 		ctxLogger := FromContext(ctx)
 		assert.Same(t, logger, ctxLogger)


### PR DESCRIPTION
This adds support for setting and getting a `Logger` from a context using `WithContext` for including the `Logger` in a `context.Context`, and `FromContext` for retrieving it from the context.

If a `Logger` isn't already included in the context, `FromContext` will return a `NewNilLogger` instead so it can be assumed that a `Logger` exists.